### PR TITLE
fix: replace `Queue` with `Bus` facade

### DIFF
--- a/src/LaravelServiceMockingRector.php
+++ b/src/LaravelServiceMockingRector.php
@@ -19,8 +19,7 @@ final class LaravelServiceMockingRector extends AbstractRector
 {
     public function __construct(
         private BetterNodeFinder $betterNodeFinder
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -29,53 +28,53 @@ final class LaravelServiceMockingRector extends AbstractRector
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
-class SomeClassTest
-{
-    public function testExpectsEvents(): void
-    {
-        $this->expectsEvents([EventA::class, EventB::class]);
-    }
+                        class SomeClassTest
+                        {
+                            public function testExpectsEvents(): void
+                            {
+                                $this->expectsEvents([EventA::class, EventB::class]);
+                            }
 
-    public function testExpectsJobs(): void
-    {
-        $this->expectsJobs([Job::class]);
-    }
+                            public function testExpectsJobs(): void
+                            {
+                                $this->expectsJobs([Job::class]);
+                            }
 
-    public function testExpectsNotification(): void
-    {
-        $this->expectsNotification([
-            NotificationA::class,
-            NotificationB::class,
-        ]);
-    }
-}
-CODE_SAMPLE,
+                            public function testExpectsNotification(): void
+                            {
+                                $this->expectsNotification([
+                                    NotificationA::class,
+                                    NotificationB::class,
+                                ]);
+                            }
+                        }
+                        CODE_SAMPLE,
                     <<<'CODE_SAMPLE'
-class SomeClassTest
-{
-    public function testExpectsEvents(): void
-    {
-        \Illuminate\Support\Facades\Event::fake([EventA::class, EventB::class])->assertDispatched([EventA::class, EventB::class]);
-    }
+                        class SomeClassTest
+                        {
+                            public function testExpectsEvents(): void
+                            {
+                                \Illuminate\Support\Facades\Event::fake([EventA::class, EventB::class])->assertDispatched([EventA::class, EventB::class]);
+                            }
 
-    public function testExpectsJobs(): void
-    {
-        \Illuminate\Support\Facades\Bus::fake([Job::class])->assertDispatched([Job::class]);
-    }
+                            public function testExpectsJobs(): void
+                            {
+                                \Illuminate\Support\Facades\Bus::fake([Job::class])->assertDispatched([Job::class]);
+                            }
 
-    public function testExpectsNotification(): void
-    {
-        \Illuminate\Support\Facades\Notification::fake([
-            NotificationA::class,
-            NotificationB::class,
-        ])->assertSentTo([
-            NotificationA::class,
-            NotificationB::class,
-        ]);
-    }
-}
-CODE_SAMPLE
-                )
+                            public function testExpectsNotification(): void
+                            {
+                                \Illuminate\Support\Facades\Notification::fake([
+                                    NotificationA::class,
+                                    NotificationB::class,
+                                ])->assertSentTo([
+                                    NotificationA::class,
+                                    NotificationB::class,
+                                ]);
+                            }
+                        }
+                        CODE_SAMPLE
+                ),
             ]
         );
     }
@@ -95,7 +94,7 @@ CODE_SAMPLE
     {
         $subNode = $this->betterNodeFinder->findFirstInstanceOf($node, MethodCall::class);
 
-        if (! $subNode) {
+        if (!$subNode) {
             return null;
         }
 
@@ -109,6 +108,7 @@ CODE_SAMPLE
                     $subNode->args
                 );
                 $subNode->name = new Identifier('assertDispatched');
+
                 return $node;
 
             case 'doesntExpectsEvents':
@@ -118,6 +118,7 @@ CODE_SAMPLE
                     $subNode->args
                 );
                 $subNode->name = new Identifier('assertNotDispatched');
+
                 return $node;
 
             case 'expectsJobs':
@@ -127,6 +128,7 @@ CODE_SAMPLE
                     $subNode->args
                 );
                 $subNode->name = new Identifier('assertDispatched');
+
                 return $node;
 
             case 'doesntExpectsJobs':
@@ -136,6 +138,7 @@ CODE_SAMPLE
                     $subNode->args
                 );
                 $subNode->name = new Identifier('assertNotDispatched');
+
                 return $node;
 
             case 'expectsNotification':
@@ -145,6 +148,7 @@ CODE_SAMPLE
                     $subNode->args
                 );
                 $subNode->name = new Identifier('assertSentTo');
+
                 return $node;
 
             default:

--- a/src/LaravelServiceMockingRector.php
+++ b/src/LaravelServiceMockingRector.php
@@ -60,7 +60,7 @@ class SomeClassTest
 
     public function testExpectsJobs(): void
     {
-        \Illuminate\Support\Facades\Queue::fake([Job::class])->assertPushed([Job::class]);
+        \Illuminate\Support\Facades\Bus::fake([Job::class])->assertDispatched([Job::class]);
     }
 
     public function testExpectsNotification(): void
@@ -122,20 +122,20 @@ CODE_SAMPLE
 
             case 'expectsJobs':
                 $subNode->var = new StaticCall(
-                    new FullyQualified('Illuminate\Support\Facades\Queue'),
+                    new FullyQualified('Illuminate\Support\Facades\Bus'),
                     'fake',
                     $subNode->args
                 );
-                $subNode->name = new Identifier('assertPushed');
+                $subNode->name = new Identifier('assertDispatched');
                 return $node;
 
             case 'doesntExpectsJobs':
                 $subNode->var = new StaticCall(
-                    new FullyQualified('Illuminate\Support\Facades\Queue'),
+                    new FullyQualified('Illuminate\Support\Facades\Bus'),
                     'fake',
                     $subNode->args
                 );
-                $subNode->name = new Identifier('assertNotPushed');
+                $subNode->name = new Identifier('assertNotDispatched');
                 return $node;
 
             case 'expectsNotification':
@@ -150,7 +150,5 @@ CODE_SAMPLE
             default:
                 return null;
         }
-
-        return null;
     }
 }

--- a/tests/LaravelServiceMockingRectorTest.php
+++ b/tests/LaravelServiceMockingRectorTest.php
@@ -4,27 +4,31 @@ declare(strict_types=1);
 
 namespace Remarkablemark\Tests\LaravelServiceMockingRector;
 
-use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 final class LaravelServiceMockingRectorTest extends AbstractRectorTestCase
 {
     /**
-     * @dataProvider provideData
+     * @dataProvider provideCases
      */
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public static function provideData(): Iterator
+    public static function provideCases(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/config/rector-config.php';
+        return __DIR__.'/config/rector-config.php';
     }
 }

--- a/tests/fixture/TestFixture.php.inc
+++ b/tests/fixture/TestFixture.php.inc
@@ -9,9 +9,19 @@ class SomeClassTest
         $this->expectsEvents([EventA::class, EventB::class]);
     }
 
+    public function testDoesntExpectsEvents(): void
+    {
+        $this->doesntExpectsEvents([EventA::class, EventB::class]);
+    }
+
     public function testExpectsJobs(): void
     {
         $this->expectsJobs([Job::class]);
+    }
+
+    public function testDoesntExpectsJobs(): void
+    {
+        $this->doesntExpectsJobs([Job::class]);
     }
 
     public function testExpectsNotification(): void
@@ -34,9 +44,19 @@ class SomeClassTest
         \Illuminate\Support\Facades\Event::fake([EventA::class, EventB::class])->assertDispatched([EventA::class, EventB::class]);
     }
 
+    public function testDoesntExpectsEvents(): void
+    {
+        \Illuminate\Support\Facades\Event::fake([EventA::class, EventB::class])->assertNotDispatched([EventA::class, EventB::class]);
+    }
+
     public function testExpectsJobs(): void
     {
         \Illuminate\Support\Facades\Bus::fake([Job::class])->assertDispatched([Job::class]);
+    }
+
+    public function testDoesntExpectsJobs(): void
+    {
+        \Illuminate\Support\Facades\Bus::fake([Job::class])->assertNotDispatched([Job::class]);
     }
 
     public function testExpectsNotification(): void

--- a/tests/fixture/TestFixture.php.inc
+++ b/tests/fixture/TestFixture.php.inc
@@ -36,7 +36,7 @@ class SomeClassTest
 
     public function testExpectsJobs(): void
     {
-        \Illuminate\Support\Facades\Queue::fake([Job::class])->assertPushed([Job::class]);
+        \Illuminate\Support\Facades\Bus::fake([Job::class])->assertDispatched([Job::class]);
     }
 
     public function testExpectsNotification(): void


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: replace `Queue` with `Bus` facade

## What is the current behavior?

- `expectsJobs` -> `Queue` `assertPushed`
- `doesntExpectsJobs` -> `Queue` `assertNotPushed`

## What is the new behavior?

- `expectsJobs` -> `Bus` `assertDispatched`
- `doesntExpectsJobs` -> `Bus` `assertNotDispatched`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation