### PR TITLE
fix: fix test method names `doesntExpectEvents` and `doesntExpectJobs`

### DIFF
--- a/src/LaravelServiceMockingRector.php
+++ b/src/LaravelServiceMockingRector.php
@@ -119,7 +119,7 @@ final class LaravelServiceMockingRector extends AbstractRector
 
                     break;
 
-                case 'doesntExpectsEvents':
+                case 'doesntExpectEvents':
                     $subNode->var = new StaticCall(
                         new FullyQualified('Illuminate\Support\Facades\Event'),
                         'fake',
@@ -141,7 +141,7 @@ final class LaravelServiceMockingRector extends AbstractRector
 
                     break;
 
-                case 'doesntExpectsJobs':
+                case 'doesntExpectJobs':
                     $subNode->var = new StaticCall(
                         new FullyQualified('Illuminate\Support\Facades\Bus'),
                         'fake',

--- a/tests/fixture/TestFixture.php.inc
+++ b/tests/fixture/TestFixture.php.inc
@@ -9,9 +9,9 @@ class SomeClassTest
         $this->expectsEvents([EventA::class, EventB::class]);
     }
 
-    public function testDoesntExpectsEvents(): void
+    public function testDoesntExpectEvents(): void
     {
-        $this->doesntExpectsEvents([EventA::class, EventB::class]);
+        $this->doesntExpectEvents([EventA::class, EventB::class]);
     }
 
     public function testExpectsJobs(): void
@@ -19,9 +19,9 @@ class SomeClassTest
         $this->expectsJobs([Job::class]);
     }
 
-    public function testDoesntExpectsJobs(): void
+    public function testDoesntExpectJobs(): void
     {
-        $this->doesntExpectsJobs([Job::class]);
+        $this->doesntExpectJobs([Job::class]);
     }
 
     public function testExpectsNotification(): void
@@ -44,7 +44,7 @@ class SomeClassTest
         \Illuminate\Support\Facades\Event::fake([EventA::class, EventB::class])->assertDispatched([EventA::class, EventB::class]);
     }
 
-    public function testDoesntExpectsEvents(): void
+    public function testDoesntExpectEvents(): void
     {
         \Illuminate\Support\Facades\Event::fake([EventA::class, EventB::class])->assertNotDispatched([EventA::class, EventB::class]);
     }
@@ -54,7 +54,7 @@ class SomeClassTest
         \Illuminate\Support\Facades\Bus::fake([Job::class])->assertDispatched([Job::class]);
     }
 
-    public function testDoesntExpectsJobs(): void
+    public function testDoesntExpectJobs(): void
     {
         \Illuminate\Support\Facades\Bus::fake([Job::class])->assertNotDispatched([Job::class]);
     }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: fix test method names `doesntExpectEvents` and `doesntExpectJobs`

## What is the current behavior?

Invalid test method names `doesntExpectsEvents` and `doesntExpectsJobs`

## What is the new behavior?

Fixed test method names `doesntExpectEvents` and `doesntExpectJobs`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation