### PR TITLE
fix: skip refactor if method is not on $this variable

### DIFF
--- a/src/LaravelServiceMockingRector.php
+++ b/src/LaravelServiceMockingRector.php
@@ -105,6 +105,12 @@ final class LaravelServiceMockingRector extends AbstractRector
         $hasChanged = false;
 
         foreach ($subNodes as $subNode) {
+            $variableName = $this->getName($subNode->var);
+
+            if ($variableName !== 'this') {
+                continue;
+            }
+
             $methodName = $this->getName($subNode->name);
 
             switch ($methodName) {

--- a/src/LaravelServiceMockingRector.php
+++ b/src/LaravelServiceMockingRector.php
@@ -107,7 +107,7 @@ final class LaravelServiceMockingRector extends AbstractRector
         foreach ($subNodes as $subNode) {
             $variableName = $this->getName($subNode->var);
 
-            if ($variableName !== 'this') {
+            if ('this' !== $variableName) {
                 continue;
             }
 

--- a/tests/fixture/SkipRuleTestFixture.php.inc
+++ b/tests/fixture/SkipRuleTestFixture.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Package\Tests\Rector\Fixture;
 
 class SomeClassTest
@@ -7,11 +9,13 @@ class SomeClassTest
     public function testExpectsEvents(): void
     {
         $this->expectsEventsFoo([EventA::class, EventB::class]);
+        $foo->expectsEvents([Job::class]);
     }
 
     public function testExpectsJobs(): void
     {
-        $bar->expectsJobsBar([Job::class]);
+        $this->expectsJobsBar([Job::class]);
+        $bar->expectsJobs([Job::class]);
     }
 
     public function testExpectsNotifications(): void
@@ -20,5 +24,8 @@ class SomeClassTest
             NotificationA::class,
             NotificationB::class,
         ]);
+        $baz->expectsNotifications([Job::class]);
     }
 }
+
+$expectsEvents([EventA::class]);

--- a/tests/fixture/TestFixture.php.inc
+++ b/tests/fixture/TestFixture.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Package\Tests\Rector\Fixture;
 
 class SomeClassTest
@@ -34,6 +36,8 @@ class SomeClassTest
 }
 -----
 <?php
+
+declare(strict_types=1);
 
 namespace Package\Tests\Rector\Fixture;
 


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: skip refactor if method is not on $this variable

## What is the current behavior?

Refactor refactors if test method is not on `$this` variable

## What is the new behavior?

Refactor does not refactor if test method is not on `$this` variable

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation